### PR TITLE
resolve 'default-language' warning with 'make run'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist-*
 cabal-dev
 *.o
 *.hi
+*.hie
 *.chi
 *.chs.h
 *.dyn_o
@@ -17,6 +18,9 @@ cabal.sandbox.config
 *.eventlog
 .stack-work/
 cabal.project.local
+cabal.project.local~
+.HTF/
+.ghc.environment.*
 
 # Windows specific
 *.exe

--- a/FizzBuzzHaskell.cabal
+++ b/FizzBuzzHaskell.cabal
@@ -70,3 +70,4 @@ Test-Suite test-foo
     main-is:    Test.hs
     other-modules:      FizzBuzz
     build-depends: base, test-framework, test-framework-hunit, HUnit
+    default-language:    Haskell2010

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,17 @@ all: test
 
 .PHONY: clean
 clean:
-	rm -rf dist
+	rm -rf \
+	dist \
+	dist-newstyle \
+	.ghc.environment.* \
+	cabal.project.local \
+	cabal.project.local~
 
 .PHONY: test
 test:
-	cabal configure --enable-tests && cabal build && cabal test
+	cabal v2-configure --enable-tests && cabal v2-build && cabal v2-test
 
 .PHONY: run
 run:
-	cabal run
+	cabal v2-run FizzBuzzHaskell


### PR DESCRIPTION
Configuring FizzBuzzHaskell-0.1.0.0...
Warning: Packages using 'cabal-version: >= 1.10' must specify the
'default-language' field for each component (e.g. Haskell98 or Haskell2010).
If a component uses different languages in different modules then list the
other ones in the 'other-languages' field.